### PR TITLE
feat: Replace frontend mocks and implement exercise updates

### DIFF
--- a/backend/src/main/java/com/ikr/lift_log/controller/ExerciseController.java
+++ b/backend/src/main/java/com/ikr/lift_log/controller/ExerciseController.java
@@ -1,10 +1,12 @@
 package com.ikr.lift_log.controller;
 
+import com.ikr.lift_log.controller.dto.ExerciseRequest;
 import com.ikr.lift_log.domain.model.Exercise;
 import com.ikr.lift_log.service.ExerciseService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid; // For @Valid if request body validation is added
 import java.util.List;
 import java.util.UUID;
 
@@ -29,5 +31,13 @@ public class ExerciseController {
         return exerciseService.getExerciseById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Exercise> updateExercise(
+            @PathVariable UUID id,
+            @RequestBody @Valid ExerciseRequest exerciseRequest) { // Added @Valid for potential future validation
+        Exercise updatedExercise = exerciseService.updateExercise(id, exerciseRequest);
+        return ResponseEntity.ok(updatedExercise);
     }
 }

--- a/backend/src/main/java/com/ikr/lift_log/controller/dto/ExerciseRequest.java
+++ b/backend/src/main/java/com/ikr/lift_log/controller/dto/ExerciseRequest.java
@@ -1,16 +1,21 @@
 package com.ikr.lift_log.controller.dto;
 
+import java.util.List;
+import java.util.UUID;
+
 public class ExerciseRequest {
     private String name;
     private String description;
+    private List<ExerciseMuscleGroupItemRequest> muscleGroups;
 
     // コンストラクタ
     public ExerciseRequest() {
     }
 
-    public ExerciseRequest(String name, String description) {
+    public ExerciseRequest(String name, String description, List<ExerciseMuscleGroupItemRequest> muscleGroups) {
         this.name = name;
         this.description = description;
+        this.muscleGroups = muscleGroups;
     }
 
     // ゲッターとセッター
@@ -28,5 +33,47 @@ public class ExerciseRequest {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public List<ExerciseMuscleGroupItemRequest> getMuscleGroups() {
+        return muscleGroups;
+    }
+
+    public void setMuscleGroups(List<ExerciseMuscleGroupItemRequest> muscleGroups) {
+        this.muscleGroups = muscleGroups;
+    }
+
+    // Inner class for muscle group items
+    public static class ExerciseMuscleGroupItemRequest {
+        private UUID muscleGroupId;
+        private Boolean isPrimary; // Use Boolean to allow null, default to false if not provided
+
+        public ExerciseMuscleGroupItemRequest() {
+        }
+
+        public ExerciseMuscleGroupItemRequest(UUID muscleGroupId, Boolean isPrimary) {
+            this.muscleGroupId = muscleGroupId;
+            this.isPrimary = isPrimary;
+        }
+
+        public UUID getMuscleGroupId() {
+            return muscleGroupId;
+        }
+
+        public void setMuscleGroupId(UUID muscleGroupId) {
+            this.muscleGroupId = muscleGroupId;
+        }
+
+        public Boolean getPrimary() { // Getter for Boolean
+            return isPrimary;
+        }
+
+        public void setPrimary(Boolean primary) { // Setter for Boolean
+            isPrimary = primary;
+        }
+        
+        public boolean isPrimaryEffective() { // Helper to get effective boolean value
+            return isPrimary != null && isPrimary;
+        }
     }
 }

--- a/backend/src/main/java/com/ikr/lift_log/domain/repository/ExerciseMuscleGroupRepository.java
+++ b/backend/src/main/java/com/ikr/lift_log/domain/repository/ExerciseMuscleGroupRepository.java
@@ -14,4 +14,6 @@ public interface ExerciseMuscleGroupRepository {
     ExerciseMuscleGroup save(ExerciseMuscleGroup exerciseMuscleGroup);
 
     void deleteById(UUID id);
+
+    void deleteByExerciseId(UUID exerciseId);
 }

--- a/backend/src/main/java/com/ikr/lift_log/domain/repository/ExerciseRepository.java
+++ b/backend/src/main/java/com/ikr/lift_log/domain/repository/ExerciseRepository.java
@@ -9,4 +9,6 @@ public interface ExerciseRepository {
     List<Exercise> findAll();
 
     Optional<Exercise> findById(UUID id);
+
+    Exercise save(Exercise exercise);
 }

--- a/backend/src/main/java/com/ikr/lift_log/service/ExerciseService.java
+++ b/backend/src/main/java/com/ikr/lift_log/service/ExerciseService.java
@@ -1,8 +1,14 @@
 package com.ikr.lift_log.service;
 
+import com.ikr.lift_log.controller.dto.ExerciseRequest;
 import com.ikr.lift_log.domain.model.Exercise;
+import com.ikr.lift_log.domain.model.ExerciseMuscleGroup;
+import com.ikr.lift_log.domain.repository.ExerciseMuscleGroupRepository;
 import com.ikr.lift_log.domain.repository.ExerciseRepository;
+import com.ikr.lift_log.domain.repository.MuscleGroupRepository;
+import com.ikr.lift_log.service.exception.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,9 +18,15 @@ import java.util.UUID;
 public class ExerciseService {
 
     private final ExerciseRepository exerciseRepository;
+    private final ExerciseMuscleGroupRepository exerciseMuscleGroupRepository;
+    private final MuscleGroupRepository muscleGroupRepository;
 
-    public ExerciseService(ExerciseRepository exerciseRepository) {
+    public ExerciseService(ExerciseRepository exerciseRepository,
+                           ExerciseMuscleGroupRepository exerciseMuscleGroupRepository,
+                           MuscleGroupRepository muscleGroupRepository) {
         this.exerciseRepository = exerciseRepository;
+        this.exerciseMuscleGroupRepository = exerciseMuscleGroupRepository;
+        this.muscleGroupRepository = muscleGroupRepository;
     }
 
     public List<Exercise> getAllExercises() {
@@ -23,5 +35,36 @@ public class ExerciseService {
 
     public Optional<Exercise> getExerciseById(UUID id) {
         return exerciseRepository.findById(id);
+    }
+
+    @Transactional
+    public Exercise updateExercise(UUID exerciseId, ExerciseRequest exerciseRequest) {
+        Exercise exercise = exerciseRepository.findById(exerciseId)
+                .orElseThrow(() -> new ResourceNotFoundException("Exercise not found with id: " + exerciseId));
+
+        exercise.setName(exerciseRequest.getName());
+        exercise.setDescription(exerciseRequest.getDescription());
+
+        // Update muscle groups
+        // 1. Delete existing associations
+        exerciseMuscleGroupRepository.deleteByExerciseId(exerciseId);
+
+        // 2. Add new associations if provided
+        if (exerciseRequest.getMuscleGroups() != null && !exerciseRequest.getMuscleGroups().isEmpty()) {
+            for (ExerciseRequest.ExerciseMuscleGroupItemRequest itemRequest : exerciseRequest.getMuscleGroups()) {
+                // Ensure the muscle group exists
+                muscleGroupRepository.findById(itemRequest.getMuscleGroupId())
+                        .orElseThrow(() -> new ResourceNotFoundException("MuscleGroup not found with id: " + itemRequest.getMuscleGroupId()));
+
+                ExerciseMuscleGroup newAssociation = new ExerciseMuscleGroup();
+                newAssociation.setId(UUID.randomUUID()); // Generate new UUID for the association
+                newAssociation.setExerciseId(exerciseId);
+                newAssociation.setMuscleGroupId(itemRequest.getMuscleGroupId());
+                newAssociation.setPrimary(itemRequest.isPrimaryEffective()); // Use the helper method
+                exerciseMuscleGroupRepository.save(newAssociation);
+            }
+        }
+
+        return exerciseRepository.save(exercise);
     }
 }

--- a/backend/src/main/java/com/ikr/lift_log/service/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/ikr/lift_log/service/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.ikr.lift_log.service.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/test/java/com/ikr/lift_log/service/ExerciseServiceTest.java
+++ b/backend/src/test/java/com/ikr/lift_log/service/ExerciseServiceTest.java
@@ -1,0 +1,248 @@
+package com.ikr.lift_log.service;
+
+import com.ikr.lift_log.controller.dto.ExerciseRequest;
+import com.ikr.lift_log.domain.model.Exercise;
+import com.ikr.lift_log.domain.model.ExerciseMuscleGroup;
+import com.ikr.lift_log.domain.model.MuscleGroup;
+import com.ikr.lift_log.domain.repository.ExerciseMuscleGroupRepository;
+import com.ikr.lift_log.domain.repository.ExerciseRepository;
+import com.ikr.lift_log.domain.repository.MuscleGroupRepository;
+import com.ikr.lift_log.service.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ExerciseServiceTest {
+
+    @Mock
+    private ExerciseRepository exerciseRepository;
+
+    @Mock
+    private ExerciseMuscleGroupRepository exerciseMuscleGroupRepository;
+
+    @Mock
+    private MuscleGroupRepository muscleGroupRepository;
+
+    @InjectMocks
+    private ExerciseService exerciseService;
+
+    private UUID exerciseId;
+    private Exercise existingExercise;
+    private ExerciseRequest exerciseRequest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        exerciseId = UUID.randomUUID();
+
+        existingExercise = new Exercise();
+        existingExercise.setId(exerciseId);
+        existingExercise.setName("Old Name");
+        existingExercise.setDescription("Old Description");
+        existingExercise.setCreatedAt(ZonedDateTime.now());
+
+        exerciseRequest = new ExerciseRequest();
+        exerciseRequest.setName("New Name");
+        exerciseRequest.setDescription("New Description");
+    }
+
+    @Test
+    void testUpdateExercise_Success_NameDescriptionOnly() {
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(exerciseRepository.save(any(Exercise.class))).thenReturn(existingExercise);
+        exerciseRequest.setMuscleGroups(Collections.emptyList());
+
+        Exercise updatedExercise = exerciseService.updateExercise(exerciseId, exerciseRequest);
+
+        assertNotNull(updatedExercise);
+        assertEquals("New Name", updatedExercise.getName());
+        assertEquals("New Description", updatedExercise.getDescription());
+        verify(exerciseRepository, times(1)).findById(exerciseId);
+        verify(exerciseMuscleGroupRepository, times(1)).deleteByExerciseId(exerciseId);
+        verify(exerciseMuscleGroupRepository, never()).save(any());
+        verify(exerciseRepository, times(1)).save(existingExercise);
+    }
+
+    @Test
+    void testUpdateExercise_Success_AddMuscleGroups() {
+        UUID muscleGroupId1 = UUID.randomUUID();
+        MuscleGroup mg1 = new MuscleGroup(muscleGroupId1, "Chest", ZonedDateTime.now());
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item1 = new ExerciseRequest.ExerciseMuscleGroupItemRequest(muscleGroupId1, true);
+
+        exerciseRequest.setMuscleGroups(List.of(item1));
+
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(muscleGroupRepository.findById(muscleGroupId1)).thenReturn(Optional.of(mg1));
+        when(exerciseMuscleGroupRepository.save(any(ExerciseMuscleGroup.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(exerciseRepository.save(any(Exercise.class))).thenReturn(existingExercise);
+
+        Exercise updatedExercise = exerciseService.updateExercise(exerciseId, exerciseRequest);
+
+        assertNotNull(updatedExercise);
+        verify(exerciseMuscleGroupRepository, times(1)).deleteByExerciseId(exerciseId);
+        
+        ArgumentCaptor<ExerciseMuscleGroup> emgCaptor = ArgumentCaptor.forClass(ExerciseMuscleGroup.class);
+        verify(exerciseMuscleGroupRepository, times(1)).save(emgCaptor.capture());
+        
+        ExerciseMuscleGroup savedEmg = emgCaptor.getValue();
+        assertEquals(exerciseId, savedEmg.getExerciseId());
+        assertEquals(muscleGroupId1, savedEmg.getMuscleGroupId());
+        assertTrue(savedEmg.isPrimary());
+        
+        verify(exerciseRepository, times(1)).save(existingExercise);
+    }
+
+    @Test
+    void testUpdateExercise_Success_ChangeMuscleGroups() {
+        UUID oldMuscleGroupId = UUID.randomUUID(); // Assume this was an old one, now removed by deleteByExerciseId
+        UUID newMuscleGroupId1 = UUID.randomUUID();
+        UUID newMuscleGroupId2 = UUID.randomUUID();
+
+        MuscleGroup mg1 = new MuscleGroup(newMuscleGroupId1, "Back", ZonedDateTime.now());
+        MuscleGroup mg2 = new MuscleGroup(newMuscleGroupId2, "Biceps", ZonedDateTime.now());
+
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item1 = new ExerciseRequest.ExerciseMuscleGroupItemRequest(newMuscleGroupId1, true);
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item2 = new ExerciseRequest.ExerciseMuscleGroupItemRequest(newMuscleGroupId2, false);
+        exerciseRequest.setMuscleGroups(List.of(item1, item2));
+
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(muscleGroupRepository.findById(newMuscleGroupId1)).thenReturn(Optional.of(mg1));
+        when(muscleGroupRepository.findById(newMuscleGroupId2)).thenReturn(Optional.of(mg2));
+        when(exerciseMuscleGroupRepository.save(any(ExerciseMuscleGroup.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(exerciseRepository.save(any(Exercise.class))).thenReturn(existingExercise);
+
+        exerciseService.updateExercise(exerciseId, exerciseRequest);
+
+        verify(exerciseMuscleGroupRepository, times(1)).deleteByExerciseId(exerciseId);
+        
+        ArgumentCaptor<ExerciseMuscleGroup> emgCaptor = ArgumentCaptor.forClass(ExerciseMuscleGroup.class);
+        verify(exerciseMuscleGroupRepository, times(2)).save(emgCaptor.capture());
+        
+        List<ExerciseMuscleGroup> savedEmgs = emgCaptor.getAllValues();
+        assertTrue(savedEmgs.stream().anyMatch(emg -> emg.getMuscleGroupId().equals(newMuscleGroupId1) && emg.isPrimary()));
+        assertTrue(savedEmgs.stream().anyMatch(emg -> emg.getMuscleGroupId().equals(newMuscleGroupId2) && !emg.isPrimary()));
+        
+        verify(exerciseRepository, times(1)).save(existingExercise);
+    }
+    
+    @Test
+    void testUpdateExercise_Success_ChangePrimaryMuscleGroup() {
+        UUID muscleGroupId1 = UUID.randomUUID();
+        UUID muscleGroupId2 = UUID.randomUUID();
+        MuscleGroup mg1 = new MuscleGroup(muscleGroupId1, "Shoulders", ZonedDateTime.now());
+        MuscleGroup mg2 = new MuscleGroup(muscleGroupId2, "Triceps", ZonedDateTime.now());
+
+        // Initially, mg1 is primary
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item1Old = new ExerciseRequest.ExerciseMuscleGroupItemRequest(muscleGroupId1, true);
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item2Old = new ExerciseRequest.ExerciseMuscleGroupItemRequest(muscleGroupId2, false);
+        // No need to set this in request, this is just for conceptual old state. The update will set the new state.
+
+        // Now, mg2 becomes primary
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item1New = new ExerciseRequest.ExerciseMuscleGroupItemRequest(muscleGroupId1, false);
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item2New = new ExerciseRequest.ExerciseMuscleGroupItemRequest(muscleGroupId2, true);
+        exerciseRequest.setMuscleGroups(List.of(item1New, item2New));
+
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(muscleGroupRepository.findById(muscleGroupId1)).thenReturn(Optional.of(mg1));
+        when(muscleGroupRepository.findById(muscleGroupId2)).thenReturn(Optional.of(mg2));
+        when(exerciseMuscleGroupRepository.save(any(ExerciseMuscleGroup.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(exerciseRepository.save(any(Exercise.class))).thenReturn(existingExercise);
+
+        exerciseService.updateExercise(exerciseId, exerciseRequest);
+
+        ArgumentCaptor<ExerciseMuscleGroup> emgCaptor = ArgumentCaptor.forClass(ExerciseMuscleGroup.class);
+        verify(exerciseMuscleGroupRepository, times(2)).save(emgCaptor.capture());
+        List<ExerciseMuscleGroup> capturedEmgs = emgCaptor.getAllValues();
+
+        ExerciseMuscleGroup emgForMg1 = capturedEmgs.stream().filter(e -> e.getMuscleGroupId().equals(muscleGroupId1)).findFirst().orElse(null);
+        ExerciseMuscleGroup emgForMg2 = capturedEmgs.stream().filter(e -> e.getMuscleGroupId().equals(muscleGroupId2)).findFirst().orElse(null);
+
+        assertNotNull(emgForMg1);
+        assertFalse(emgForMg1.isPrimary());
+        assertNotNull(emgForMg2);
+        assertTrue(emgForMg2.isPrimary());
+    }
+
+
+    @Test
+    void testUpdateExercise_Success_RemoveAllMuscleGroups() {
+        // Assume exercise previously had muscle groups, they will be cleared by deleteByExerciseId
+        exerciseRequest.setMuscleGroups(new ArrayList<>()); // Empty list
+
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(exerciseRepository.save(any(Exercise.class))).thenReturn(existingExercise);
+
+        Exercise updatedExercise = exerciseService.updateExercise(exerciseId, exerciseRequest);
+
+        assertNotNull(updatedExercise);
+        verify(exerciseMuscleGroupRepository, times(1)).deleteByExerciseId(exerciseId);
+        verify(exerciseMuscleGroupRepository, never()).save(any(ExerciseMuscleGroup.class));
+        verify(exerciseRepository, times(1)).save(existingExercise);
+    }
+    
+    @Test
+    void testUpdateExercise_Success_NullMuscleGroupsList() {
+        // This tests if muscleGroups list in request is null (not just empty)
+        exerciseRequest.setMuscleGroups(null); 
+
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(exerciseRepository.save(any(Exercise.class))).thenReturn(existingExercise);
+
+        Exercise updatedExercise = exerciseService.updateExercise(exerciseId, exerciseRequest);
+
+        assertNotNull(updatedExercise);
+        assertEquals("New Name", updatedExercise.getName());
+        verify(exerciseMuscleGroupRepository, times(1)).deleteByExerciseId(exerciseId);
+        verify(exerciseMuscleGroupRepository, never()).save(any(ExerciseMuscleGroup.class));
+        verify(exerciseRepository, times(1)).save(existingExercise);
+    }
+
+
+    @Test
+    void testUpdateExercise_Error_ExerciseNotFound() {
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {
+            exerciseService.updateExercise(exerciseId, exerciseRequest);
+        });
+
+        assertEquals("Exercise not found with id: " + exerciseId, exception.getMessage());
+        verify(exerciseMuscleGroupRepository, never()).deleteByExerciseId(any());
+        verify(exerciseMuscleGroupRepository, never()).save(any());
+        verify(exerciseRepository, never()).save(any());
+    }
+
+    @Test
+    void testUpdateExercise_Error_MuscleGroupNotFound() {
+        UUID muscleGroupId1 = UUID.randomUUID();
+        ExerciseRequest.ExerciseMuscleGroupItemRequest item1 = new ExerciseRequest.ExerciseMuscleGroupItemRequest(muscleGroupId1, true);
+        exerciseRequest.setMuscleGroups(List.of(item1));
+
+        when(exerciseRepository.findById(exerciseId)).thenReturn(Optional.of(existingExercise));
+        when(muscleGroupRepository.findById(muscleGroupId1)).thenReturn(Optional.empty()); // Muscle group not found
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> {
+            exerciseService.updateExercise(exerciseId, exerciseRequest);
+        });
+
+        assertEquals("MuscleGroup not found with id: " + muscleGroupId1, exception.getMessage());
+        // deleteByExerciseId should still be called as it's before the loop
+        verify(exerciseMuscleGroupRepository, times(1)).deleteByExerciseId(exerciseId);
+        verify(exerciseMuscleGroupRepository, never()).save(any(ExerciseMuscleGroup.class)); // Save for association should not happen
+        verify(exerciseRepository, never()).save(any(Exercise.class)); // Save for exercise should not happen
+    }
+}

--- a/frontend/src/pages/ExercisesPage.tsx
+++ b/frontend/src/pages/ExercisesPage.tsx
@@ -165,14 +165,18 @@ const ExercisesPage = () => {
     if (!editingExercise) return;
     
     try {
-      // 種目の更新
-      await api.exercises.update(editingExercise.id, {
+      // 更新する種目のデータを作成
+      const exerciseUpdateData: ExerciseRequest = {
         name: editingExercise.name,
-        description: editingExercise.description,
-      });
+        description: editingExercise.description || undefined,
+        muscleGroups: selectedMuscleGroups.map(mgId => ({
+          muscleGroupId: mgId,
+          isPrimary: mgId === primaryMuscleGroup,
+        })),
+      };
       
-      // TODO: 筋肉グループの関連付け更新（API側で実装が必要）
-      // 現状のAPIでは一度削除して再度追加する必要があるかもしれません
+      // 種目の更新
+      await api.exercises.update(editingExercise.id, exerciseUpdateData);
       
       // 種目一覧を更新
       await fetchExercises();

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { User } from "@/types";
+import { api } from "@/lib/api"; // APIモジュールをインポート
 
 // 認証状態のストア
 interface AuthState {
@@ -7,29 +8,27 @@ interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
   error: string | null;
-  login: (userId: string) => Promise<void>;
+  login: () => Promise<void>; // userId引数を削除
   logout: () => void;
   clearError: () => void;
 }
+
+// ハードコードされたユーザーID
+const HARDCODED_USER_ID = "550e8400-e29b-41d4-a716-446655440000";
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isAuthenticated: false,
   isLoading: false,
   error: null,
-  login: async (userId) => {
+  login: async () => { // userId引数を削除
     set({ isLoading: true, error: null });
     try {
-      // 実際のアプリでは認証APIを使用する
-      // ここではモックのユーザーデータを使用
-      const mockUser: User = {
-        id: userId,
-        name: "テストユーザー",
-        createdAt: new Date().toISOString(),
-      };
+      // APIを呼び出してユーザー情報を取得
+      const userData = await api.users.getById(HARDCODED_USER_ID);
       // ログイン成功
       set({
-        user: mockUser,
+        user: userData, // APIからのレスポンスをセット
         isAuthenticated: true,
         isLoading: false,
       });


### PR DESCRIPTION
Frontend:
- Replaced mock user authentication in `authStore.ts` with an API call to `GET /users/{id}` using a hardcoded user ID. This is a temporary measure due to the lack of a dedicated login API endpoint.
- Updated `ExercisesPage.tsx` to correctly send the `muscleGroups` array (including `isPrimary` status) when updating an exercise via `PUT /exercises/{id}`, addressing a TODO comment.

Backend:
- Implemented the `PUT /exercises/{id}` endpoint in `ExerciseController.java` and `ExerciseService.java`.
- The service logic now handles updates to exercise name, description, and its associated muscle groups (clearing old ones, adding new ones with correct `isPrimary` status).
- Added `deleteByExerciseId` to `ExerciseMuscleGroupRepository`.
- Updated `ExerciseRequest` DTO to include `muscleGroups`.
- Added `ResourceNotFoundException` for better error handling.
- Added comprehensive JUnit tests for `ExerciseService.updateExercise` to cover various scenarios including muscle group manipulations and error conditions.

Note: Full integration testing for exercise updates will be performed by you before merging. The login system requires a future update to implement proper credential-based authentication.