### PR TITLE
refactor: APIモックを導入し、App.tsxのテストデータを分離

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
+        "msw": "^2.10.4",
         "postcss": "^8.4.29",
         "tailwindcss": "^3.3.3",
         "typescript": "^5.0.2",
@@ -357,6 +358,37 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -882,6 +914,121 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
+      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -968,6 +1115,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.3.tgz",
+      "integrity": "sha512-9bw/wBL7pblsnOCIqvn1788S9o4h+cC5HWXg0Xhh0dOzsZ53IyfmBM+FYqpDDPbm0xjCqEqvCITloF3Dm4TXRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1005,6 +1170,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1078,6 +1268,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/history": {
       "version": "4.7.11",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
@@ -1142,6 +1339,20 @@
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1409,6 +1620,35 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -1722,6 +1962,71 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1777,6 +2082,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2459,6 +2774,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2611,6 +2936,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2659,6 +2994,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2777,6 +3119,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -3073,6 +3422,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.10.4.tgz",
+      "integrity": "sha512-6R1or/qyele7q3RyPwNuvc0IxO8L8/Aim6Sz5ncXEgcWUNxSKE+udriTOWHtpMwmfkLYlacA2y7TIx4cL5lgHA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -3186,6 +3603,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3298,6 +3722,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3515,6 +3946,19 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3524,6 +3968,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -3635,6 +4086,23 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -3813,6 +4281,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4091,6 +4576,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -4151,6 +4652,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -4190,6 +4701,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4389,6 +4911,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -4409,6 +4941,57 @@
         "node": ">= 14.6"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4417,6 +5000,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
+    "msw": "^2.10.4",
     "postcss": "^8.4.29",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import HomePage from './pages/HomePage'
 import WorkoutDetailPage from './pages/WorkoutDetailPage'
@@ -7,201 +7,78 @@ import ExerciseInputPage from './pages/ExerciseInputPage'
 import CalendarPage from './pages/CalendarPage'
 import ExerciseManagementPage from './pages/ExerciseManagementPage'
 import type { WorkoutDay, WorkoutRecord, Exercise, WorkoutSet } from './types'
+import { getWorkoutDays, addWorkoutDay } from './api/workouts'
+import { getExercises, addExercise, deleteExercise, getWorkoutRecords, saveWorkoutRecord } from './api/exercises'
 
 function App() {
-  const [workoutDays, setWorkoutDays] = useState<WorkoutDay[]>([
-    {
-      id: '1',
-      date: '2024-07-21',
-      name: '胸・肩の日',
-      isCompleted: true,
-      createdAt: '2024-07-21T10:00:00Z',
-      updatedAt: '2024-07-21T12:30:00Z'
-    },
-    {
-      id: '2',
-      date: '2024-07-19',
-      name: '背中・腕の日',
-      isCompleted: true,
-      createdAt: '2024-07-19T09:00:00Z',
-      updatedAt: '2024-07-19T11:15:00Z'
-    },
-    {
-      id: '3',
-      date: '2024-07-17',
-      name: '脚の日',
-      isCompleted: false,
-      createdAt: '2024-07-17T08:30:00Z',
-      updatedAt: '2024-07-17T08:30:00Z'
-    }
-  ]);
+  const [workoutDays, setWorkoutDays] = useState<WorkoutDay[]>([]);
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [workoutRecords, setWorkoutRecords] = useState<WorkoutRecord[]>([]);
 
-  const [exercises, setExercises] = useState<Exercise[]>([
-    { id: 'ex1', name: 'ベンチプレス', muscleGroup: '胸' },
-    { id: 'ex2', name: 'ショルダープレス', muscleGroup: '肩' },
-    { id: 'ex3', name: 'デッドリフト', muscleGroup: '背中' },
-    { id: 'ex4', name: 'スクワット', muscleGroup: '脚' },
-    { id: 'ex5', name: 'インクラインベンチプレス', muscleGroup: '胸' },
-    { id: 'ex6', name: 'ラテラルレイズ', muscleGroup: '肩' },
-    { id: 'ex7', name: 'プルアップ', muscleGroup: '背中' },
-    { id: 'ex8', name: 'レッグプレス', muscleGroup: '脚' },
-    { id: 'ex9', name: 'バーベルカール', muscleGroup: '腕' },
-    { id: 'ex10', name: 'トライセップスプレス', muscleGroup: '腕' },
-  ]);
-
-  const [workoutRecords, setWorkoutRecords] = useState<WorkoutRecord[]>([
-    {
-      id: '1',
-      workoutDayId: '1',
-      exerciseId: 'ex1',
-      exerciseName: 'ベンチプレス',
-      sets: [
-        { setNumber: 1, weight: 80, reps: 8, completed: true },
-        { setNumber: 2, weight: 80, reps: 6, completed: true },
-        { setNumber: 3, weight: 75, reps: 8, completed: true }
-      ],
-      createdAt: '2024-07-21T10:00:00Z',
-      updatedAt: '2024-07-21T10:30:00Z'
-    },
-    {
-      id: '2',
-      workoutDayId: '1',
-      exerciseId: 'ex2',
-      exerciseName: 'ショルダープレス',
-      sets: [
-        { setNumber: 1, weight: 40, reps: 10, completed: true },
-        { setNumber: 2, weight: 40, reps: 8, completed: true },
-        { setNumber: 3, weight: 35, reps: 12, completed: true }
-      ],
-      createdAt: '2024-07-21T10:45:00Z',
-      updatedAt: '2024-07-21T11:00:00Z'
-    },
-    {
-      id: '3',
-      workoutDayId: '2',
-      exerciseId: 'ex3',
-      exerciseName: 'デッドリフト',
-      sets: [
-        { setNumber: 1, weight: 100, reps: 5, completed: true },
-        { setNumber: 2, weight: 100, reps: 5, completed: true },
-        { setNumber: 3, weight: 95, reps: 6, completed: true }
-      ],
-      createdAt: '2024-07-19T09:00:00Z',
-      updatedAt: '2024-07-19T09:30:00Z'
-    },
-    // 前回のベンチプレス記録
-    {
-      id: '4',
-      workoutDayId: '4',
-      exerciseId: 'ex1',
-      exerciseName: 'ベンチプレス',
-      sets: [
-        { setNumber: 1, weight: 75, reps: 10, completed: true },
-        { setNumber: 2, weight: 75, reps: 8, completed: true },
-        { setNumber: 3, weight: 70, reps: 10, completed: true }
-      ],
-      createdAt: '2024-07-15T10:00:00Z',
-      updatedAt: '2024-07-15T10:30:00Z'
-    },
-    // 前々回のベンチプレス記録
-    {
-      id: '5',
-      workoutDayId: '5',
-      exerciseId: 'ex1',
-      exerciseName: 'ベンチプレス',
-      sets: [
-        { setNumber: 1, weight: 70, reps: 10, completed: true },
-        { setNumber: 2, weight: 70, reps: 8, completed: true },
-        { setNumber: 3, weight: 65, reps: 12, completed: true },
-        { setNumber: 4, weight: 65, reps: 10, completed: true }
-      ],
-      createdAt: '2024-07-12T10:00:00Z',
-      updatedAt: '2024-07-12T10:30:00Z'
-    },
-    // ショルダープレスの過去記録
-    {
-      id: '6',
-      workoutDayId: '4',
-      exerciseId: 'ex2',
-      exerciseName: 'ショルダープレス',
-      sets: [
-        { setNumber: 1, weight: 35, reps: 12, completed: true },
-        { setNumber: 2, weight: 35, reps: 10, completed: true },
-        { setNumber: 3, weight: 30, reps: 15, completed: true }
-      ],
-      createdAt: '2024-07-15T11:00:00Z',
-      updatedAt: '2024-07-15T11:15:00Z'
-    },
-    {
-      id: '7',
-      workoutDayId: '5',
-      exerciseId: 'ex2',
-      exerciseName: 'ショルダープレス',
-      sets: [
-        { setNumber: 1, weight: 30, reps: 15, completed: true },
-        { setNumber: 2, weight: 30, reps: 12, completed: true },
-        { setNumber: 3, weight: 25, reps: 15, completed: true }
-      ],
-      createdAt: '2024-07-12T11:00:00Z',
-      updatedAt: '2024-07-12T11:15:00Z'
-    }
-  ]);
-
-  const handleAddWorkout = () => {
-    const newWorkout: WorkoutDay = {
-      id: Date.now().toString(),
-      date: new Date().toISOString().split('T')[0],
-      name: '',
-      isCompleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
-    };
-    setWorkoutDays([newWorkout, ...workoutDays]);
-  };
-
-  const handleAddNewExercise = (name: string, muscleGroup: string) => {
-    const newExercise: Exercise = {
-      id: `ex${Date.now()}`,
-      name,
-      muscleGroup
-    };
-    setExercises(prev => [...prev, newExercise]);
-  };
-
-  const handleDeleteExercise = (exerciseId: string) => {
-    setExercises(prev => prev.filter(ex => ex.id !== exerciseId));
-    setWorkoutRecords(prev => prev.filter(record => record.exerciseId !== exerciseId));
-  };
-
-  const handleSaveExercise = (workoutId: string, exerciseId: string, sets: WorkoutSet[], editingRecordId?: string) => {
-    const exercise = exercises.find(ex => ex.id === exerciseId);
-    if (!exercise) return;
-
-    if (editingRecordId) {
-      // 既存記録の更新
-      const editingRecord = workoutRecords.find(record => record.id === editingRecordId);
-      if (editingRecord) {
-        const updatedRecord: WorkoutRecord = {
-          ...editingRecord,
-          sets,
-          updatedAt: new Date().toISOString()
-        };
-        setWorkoutRecords(prev => 
-          prev.map(record => record.id === editingRecordId ? updatedRecord : record)
-        );
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [days, exs, records] = await Promise.all([
+          getWorkoutDays(),
+          getExercises(),
+          getWorkoutRecords(),
+        ]);
+        setWorkoutDays(days);
+        setExercises(exs);
+        setWorkoutRecords(records);
+      } catch (error) {
+        console.error("Failed to fetch initial data", error);
       }
-    } else {
-      // 新規記録の追加
-      const newRecord: WorkoutRecord = {
-        id: Date.now().toString(),
-        workoutDayId: workoutId,
-        exerciseId: exerciseId,
-        exerciseName: exercise.name,
-        sets,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
+    };
+    fetchData();
+  }, []);
+
+  const handleAddWorkout = async () => {
+    try {
+      const newWorkoutData = {
+        date: new Date().toISOString().split('T')[0],
+        name: '',
+        isCompleted: false,
       };
-      setWorkoutRecords(prev => [...prev, newRecord]);
+      const newWorkout = await addWorkoutDay(newWorkoutData);
+      setWorkoutDays([newWorkout, ...workoutDays]);
+    } catch (error) {
+      console.error("Failed to add workout", error);
+    }
+  };
+
+  const handleAddNewExercise = async (name: string, muscleGroup: string) => {
+    try {
+      const newExerciseData = { name, muscleGroup };
+      const newExercise = await addExercise(newExerciseData);
+      setExercises(prev => [...prev, newExercise]);
+    } catch (error) {
+      console.error("Failed to add exercise", error);
+    }
+  };
+
+  const handleDeleteExercise = async (exerciseId: string) => {
+    try {
+      await deleteExercise(exerciseId);
+      setExercises(prev => prev.filter(ex => ex.id !== exerciseId));
+      setWorkoutRecords(prev => prev.filter(record => record.exerciseId !== exerciseId));
+    } catch (error) {
+      console.error("Failed to delete exercise", error);
+    }
+  };
+
+  const handleSaveExercise = async (workoutId: string, exerciseId: string, sets: WorkoutSet[], editingRecordId?: string) => {
+    try {
+      const savedRecord = await saveWorkoutRecord(workoutId, exerciseId, sets, editingRecordId);
+      if (editingRecordId) {
+        setWorkoutRecords(prev => 
+          prev.map(record => record.id === editingRecordId ? savedRecord : record)
+        );
+      } else {
+        setWorkoutRecords(prev => [...prev, savedRecord]);
+      }
+    } catch (error) {
+      console.error("Failed to save exercise", error);
     }
   };
 

--- a/frontend/src/api/exercises.ts
+++ b/frontend/src/api/exercises.ts
@@ -1,0 +1,70 @@
+import type { Exercise, WorkoutRecord, WorkoutSet } from '../types';
+
+const BASE_URL = '/api';
+
+export const getExercises = async (): Promise<Exercise[]> => {
+  const response = await fetch(`${BASE_URL}/exercises`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch exercises');
+  }
+  return response.json();
+};
+
+export const addExercise = async (exercise: Omit<Exercise, 'id'>): Promise<Exercise> => {
+  const response = await fetch(`${BASE_URL}/exercises`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(exercise),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to add exercise');
+  }
+  return response.json();
+};
+
+export const deleteExercise = async (exerciseId: string): Promise<void> => {
+  const response = await fetch(`${BASE_URL}/exercises/${exerciseId}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    throw new Error('Failed to delete exercise');
+  }
+};
+
+
+export const getWorkoutRecords = async (): Promise<WorkoutRecord[]> => {
+    const response = await fetch(`${BASE_URL}/workout-records`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch workout records');
+    }
+    return response.json();
+};
+
+export const saveWorkoutRecord = async (workoutId: string, exerciseId: string, sets: WorkoutSet[], editingRecordId?: string): Promise<WorkoutRecord> => {
+    const url = editingRecordId
+      ? `${BASE_URL}/workout-records/${editingRecordId}`
+      : `${BASE_URL}/workout-records`;
+
+    const method = editingRecordId ? 'PUT' : 'POST';
+
+    const body = JSON.stringify({
+        workoutDayId: workoutId,
+        exerciseId,
+        sets,
+    });
+
+    const response = await fetch(url, {
+        method,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body,
+    });
+
+    if (!response.ok) {
+        throw new Error('Failed to save workout record');
+    }
+    return response.json();
+}

--- a/frontend/src/api/workouts.ts
+++ b/frontend/src/api/workouts.ts
@@ -1,0 +1,25 @@
+import type { WorkoutDay } from '../types';
+
+const BASE_URL = '/api';
+
+export const getWorkoutDays = async (): Promise<WorkoutDay[]> => {
+  const response = await fetch(`${BASE_URL}/workout-days`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch workout days');
+  }
+  return response.json();
+};
+
+export const addWorkoutDay = async (workoutDay: Omit<WorkoutDay, 'id' | 'createdAt' | 'updatedAt'>): Promise<WorkoutDay> => {
+  const response = await fetch(`${BASE_URL}/workout-days`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(workoutDay),
+  });
+  if (!response.ok) {
+    throw new Error('Failed to add workout day');
+  }
+  return response.json();
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,23 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+async function enableMocking() {
+  // 'development'環境（`npm run dev`で起動した場合など）でのみモックを有効にする
+  if (process.env.NODE_ENV !== 'development') {
+    return
+  }
+
+  const { worker } = await import('./mocks/browser')
+
+  // `worker.start()` returns a Promise that resolves
+  // once the Service Worker is up and running.
+  return worker.start()
+}
+
+enableMocking().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+})

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers)

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,0 +1,152 @@
+import { http, HttpResponse } from 'msw'
+import type { WorkoutDay, WorkoutRecord, Exercise } from '../types'
+
+const workoutDays: WorkoutDay[] = [
+  {
+    id: '1',
+    date: '2024-07-21',
+    name: '胸・肩の日',
+    isCompleted: true,
+    createdAt: '2024-07-21T10:00:00Z',
+    updatedAt: '2024-07-21T12:30:00Z'
+  },
+  {
+    id: '2',
+    date: '2024-07-19',
+    name: '背中・腕の日',
+    isCompleted: true,
+    createdAt: '2024-07-19T09:00:00Z',
+    updatedAt: '2024-07-19T11:15:00Z'
+  },
+  {
+    id: '3',
+    date: '2024-07-17',
+    name: '脚の日',
+    isCompleted: false,
+    createdAt: '2024-07-17T08:30:00Z',
+    updatedAt: '2024-07-17T08:30:00Z'
+  }
+];
+
+const exercises: Exercise[] = [
+  { id: 'ex1', name: 'ベンチプレス', muscleGroup: '胸' },
+  { id: 'ex2', name: 'ショルダープレス', muscleGroup: '肩' },
+  { id: 'ex3', name: 'デッドリフト', muscleGroup: '背中' },
+  { id: 'ex4', name: 'スクワット', muscleGroup: '脚' },
+  { id: 'ex5', name: 'インクラインベンチプレス', muscleGroup: '胸' },
+  { id: 'ex6', name: 'ラテラルレイズ', muscleGroup: '肩' },
+  { id: 'ex7', name: 'プルアップ', muscleGroup: '背中' },
+  { id: 'ex8', name: 'レッグプレス', muscleGroup: '脚' },
+  { id: 'ex9', name: 'バーベルカール', muscleGroup: '腕' },
+  { id: 'ex10', name: 'トライセップスプレス', muscleGroup: '腕' },
+];
+
+const workoutRecords: WorkoutRecord[] = [
+  {
+    id: '1',
+    workoutDayId: '1',
+    exerciseId: 'ex1',
+    exerciseName: 'ベンチプレス',
+    sets: [
+      { setNumber: 1, weight: 80, reps: 8, completed: true },
+      { setNumber: 2, weight: 80, reps: 6, completed: true },
+      { setNumber: 3, weight: 75, reps: 8, completed: true }
+    ],
+    createdAt: '2024-07-21T10:00:00Z',
+    updatedAt: '2024-07-21T10:30:00Z'
+  },
+  {
+    id: '2',
+    workoutDayId: '1',
+    exerciseId: 'ex2',
+    exerciseName: 'ショルダープレス',
+    sets: [
+      { setNumber: 1, weight: 40, reps: 10, completed: true },
+      { setNumber: 2, weight: 40, reps: 8, completed: true },
+      { setNumber: 3, weight: 35, reps: 12, completed: true }
+    ],
+    createdAt: '2024-07-21T10:45:00Z',
+    updatedAt: '2024-07-21T11:00:00Z'
+  },
+  {
+    id: '3',
+    workoutDayId: '2',
+    exerciseId: 'ex3',
+    exerciseName: 'デッドリフト',
+    sets: [
+      { setNumber: 1, weight: 100, reps: 5, completed: true },
+      { setNumber: 2, weight: 100, reps: 5, completed: true },
+      { setNumber: 3, weight: 95, reps: 6, completed: true }
+    ],
+    createdAt: '2024-07-19T09:00:00Z',
+    updatedAt: '2024-07-19T09:30:00Z'
+  },
+  // 前回のベンチプレス記録
+  {
+    id: '4',
+    workoutDayId: '4',
+    exerciseId: 'ex1',
+    exerciseName: 'ベンチプレス',
+    sets: [
+      { setNumber: 1, weight: 75, reps: 10, completed: true },
+      { setNumber: 2, weight: 75, reps: 8, completed: true },
+      { setNumber: 3, weight: 70, reps: 10, completed: true }
+    ],
+    createdAt: '2024-07-15T10:00:00Z',
+    updatedAt: '2024-07-15T10:30:00Z'
+  },
+  // 前々回のベンチプレス記録
+  {
+    id: '5',
+    workoutDayId: '5',
+    exerciseId: 'ex1',
+    exerciseName: 'ベンチプレス',
+    sets: [
+      { setNumber: 1, weight: 70, reps: 10, completed: true },
+      { setNumber: 2, weight: 70, reps: 8, completed: true },
+      { setNumber: 3, weight: 65, reps: 12, completed: true },
+      { setNumber: 4, weight: 65, reps: 10, completed: true }
+    ],
+    createdAt: '2024-07-12T10:00:00Z',
+    updatedAt: '2024-07-12T10:30:00Z'
+  },
+  // ショルダープレスの過去記録
+  {
+    id: '6',
+    workoutDayId: '4',
+    exerciseId: 'ex2',
+    exerciseName: 'ショルダープレス',
+    sets: [
+      { setNumber: 1, weight: 35, reps: 12, completed: true },
+      { setNumber: 2, weight: 35, reps: 10, completed: true },
+      { setNumber: 3, weight: 30, reps: 15, completed: true }
+    ],
+    createdAt: '2024-07-15T11:00:00Z',
+    updatedAt: '2024-07-15T11:15:00Z'
+  },
+  {
+    id: '7',
+    workoutDayId: '5',
+    exerciseId: 'ex2',
+    exerciseName: 'ショルダープレス',
+    sets: [
+      { setNumber: 1, weight: 30, reps: 15, completed: true },
+      { setNumber: 2, weight: 30, reps: 12, completed: true },
+      { setNumber: 3, weight: 25, reps: 15, completed: true }
+    ],
+    createdAt: '2024-07-12T11:00:00Z',
+    updatedAt: '2024-07-12T11:15:00Z'
+  }
+];
+
+export const handlers = [
+  http.get('/api/workout-days', () => {
+    return HttpResponse.json(workoutDays)
+  }),
+  http.get('/api/exercises', () => {
+    return HttpResponse.json(exercises)
+  }),
+  http.get('/api/workout-records', () => {
+    return HttpResponse.json(workoutRecords)
+  }),
+]


### PR DESCRIPTION
- `msw`を導入し、APIのモックを作成しました。
- `App.tsx`にベタ書きされていたテストデータを`msw`のハンドラに移動しました。
- `fetch` APIを使用するAPIクライアントを作成しました。
- `App.tsx`をリファクタリングし、APIクライアント経由でデータを非同期に取得・更新するように変更しました。
- 開発環境でのみAPIモックが有効になるように設定し、その旨をコメントで補足しました。