### PR TITLE
Allow unauthenticated user registration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -103,17 +103,11 @@
 
     <!-- Lombok -->
     <dependency>
-		<groupId>org.projectlombok</groupId>
-		<artifactId>lombok</artifactId>
-		<version>1.18.34</version>
-		<scope>compileOnly</scope>
-	</dependency>	
-	<dependency>
-		<groupId>org.projectlombok</groupId>
-		<artifactId>lombok</artifactId>
-		<version>1.18.34</version>
-		<scope>annotationProcessor</scope>
-	</dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.34</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/com/ikr/lift_log/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ikr/lift_log/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.ikr.lift_log.config;
 import com.ikr.lift_log.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -34,6 +35,7 @@ public class SecurityConfig {
                                 .authorizeHttpRequests(authz -> authz
                                                 // ログインエンドポイントは認証不要
                                                 .requestMatchers("/api/v1/auth/login").permitAll()
+                                                .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
                                                 // その他のAPIエンドポイントは認証必要
                                                 .requestMatchers("/api/**").authenticated()
                                                 // その他のリクエストは許可（静的リソースなど）

--- a/backend/src/main/java/com/ikr/lift_log/service/UserService.java
+++ b/backend/src/main/java/com/ikr/lift_log/service/UserService.java
@@ -29,6 +29,11 @@ public class UserService {
     }
 
     public User createUser(User user) {
+        // パスワードをBCryptでハッシュ化（認証時と同じ方式）
+        if (user.getPasswordHash() != null && !user.getPasswordHash().isEmpty()) {
+            String hashedPassword = passwordEncoder.encode(user.getPasswordHash());
+            user.setPasswordHash(hashedPassword);
+        }
         return userRepository.save(user);
     }
 

--- a/backend/src/test/java/com/ikr/lift_log/config/SecurityConfigTest.java
+++ b/backend/src/test/java/com/ikr/lift_log/config/SecurityConfigTest.java
@@ -1,0 +1,69 @@
+package com.ikr.lift_log.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ikr.lift_log.controller.UserController;
+import com.ikr.lift_log.domain.model.User;
+import com.ikr.lift_log.security.JwtAuthenticationFilter;
+import com.ikr.lift_log.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@Import(SecurityConfig.class)
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    void unauthenticatedUserCanCreateUser() throws Exception {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilterInternal(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+
+        User user = new User();
+        user.setId(UUID.randomUUID());
+        user.setName("John");
+        user.setEmail("john@example.com");
+        user.setPasswordHash("hash");
+
+        when(userService.createUser(any(User.class))).thenReturn(user);
+
+        String json = objectMapper.writeValueAsString(user);
+
+        mockMvc.perform(post("/api/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated());
+    }
+}
+

--- a/backend/src/test/java/com/ikr/lift_log/config/SecurityConfigTest.java
+++ b/backend/src/test/java/com/ikr/lift_log/config/SecurityConfigTest.java
@@ -3,11 +3,8 @@ package com.ikr.lift_log.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ikr.lift_log.controller.UserController;
 import com.ikr.lift_log.domain.model.User;
-import com.ikr.lift_log.security.JwtAuthenticationFilter;
+import com.ikr.lift_log.security.JwtTokenProvider;
 import com.ikr.lift_log.service.UserService;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,7 +16,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,18 +34,10 @@ class SecurityConfigTest {
     private UserService userService;
 
     @MockBean
-    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     void unauthenticatedUserCanCreateUser() throws Exception {
-        doAnswer(invocation -> {
-            HttpServletRequest request = invocation.getArgument(0);
-            HttpServletResponse response = invocation.getArgument(1);
-            FilterChain chain = invocation.getArgument(2);
-            chain.doFilter(request, response);
-            return null;
-        }).when(jwtAuthenticationFilter).doFilterInternal(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
-
         User user = new User();
         user.setId(UUID.randomUUID());
         user.setName("John");

--- a/backend/src/test/java/com/ikr/lift_log/service/UserServiceTest.java
+++ b/backend/src/test/java/com/ikr/lift_log/service/UserServiceTest.java
@@ -1,0 +1,108 @@
+package com.ikr.lift_log.service;
+
+import com.ikr.lift_log.domain.model.User;
+import com.ikr.lift_log.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class UserServiceTest {
+
+    private UserService userService;
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userService = new UserService(userRepository);
+        passwordEncoder = new BCryptPasswordEncoder(10);
+    }
+
+    @Test
+    void createUser_shouldHashPassword() {
+        // Arrange
+        String plainPassword = "testPassword123";
+        User inputUser = new User();
+        inputUser.setName("Test User");
+        inputUser.setEmail("test@example.com");
+        inputUser.setPasswordHash(plainPassword); // 平文パスワード
+
+        User savedUser = new User();
+        savedUser.setId(UUID.randomUUID());
+        savedUser.setName("Test User");
+        savedUser.setEmail("test@example.com");
+
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            savedUser.setPasswordHash(user.getPasswordHash());
+            return savedUser;
+        });
+
+        // Act
+        User result = userService.createUser(inputUser);
+
+        // Assert
+        assertNotNull(result.getPasswordHash());
+        assertNotEquals(plainPassword, result.getPasswordHash()); // ハッシュ化されている
+        assertTrue(passwordEncoder.matches(plainPassword, result.getPasswordHash())); // 平文との照合が成功
+        assertTrue(result.getPasswordHash().startsWith("$2a$10$")); // BCryptハッシュの形式
+    }
+
+    @Test
+    void createUser_withEmptyPassword_shouldNotHash() {
+        // Arrange
+        User inputUser = new User();
+        inputUser.setName("Test User");
+        inputUser.setEmail("test@example.com");
+        inputUser.setPasswordHash(""); // 空文字
+
+        User savedUser = new User();
+        savedUser.setId(UUID.randomUUID());
+        savedUser.setName("Test User");
+        savedUser.setEmail("test@example.com");
+        savedUser.setPasswordHash("");
+
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        // Act
+        User result = userService.createUser(inputUser);
+
+        // Assert
+        assertEquals("", result.getPasswordHash());
+    }
+
+    @Test
+    void createUser_withNullPassword_shouldNotHash() {
+        // Arrange
+        User inputUser = new User();
+        inputUser.setName("Test User");
+        inputUser.setEmail("test@example.com");
+        inputUser.setPasswordHash(null);
+
+        User savedUser = new User();
+        savedUser.setId(UUID.randomUUID());
+        savedUser.setName("Test User");
+        savedUser.setEmail("test@example.com");
+        savedUser.setPasswordHash(null);
+
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        // Act
+        User result = userService.createUser(inputUser);
+
+        // Assert
+        assertNull(result.getPasswordHash());
+    }
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,17 +1,28 @@
 import { BASE_URL } from './config';
 
-export const signup = async (email: string, password: string) => {
-  const response = await fetch(`${BASE_URL}/signup`, {
+export const signup = async (email: string, password: string, name: string) => {
+  
+  const response = await fetch(`${BASE_URL}/users`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ email, password }),
+    body: JSON.stringify({ 
+      name,
+      email, 
+      passwordHash: password // バックエンドはpasswordHashフィールドを期待
+    }),
   });
 
   if (!response.ok) {
-    const errorData = await response.json();
-    throw new Error(errorData.message || '新規登録に失敗しました。');
+    let errorMessage = '新規登録に失敗しました。';
+    try {
+      const errorData = await response.json();
+      errorMessage = errorData.message || errorMessage;
+    } catch {
+      // JSONパースエラーの場合はデフォルトメッセージを使用
+    }
+    throw new Error(errorMessage);
   }
 
   return response.json();

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { signup } from '../api/auth';
 
 const SignupPage: React.FC = () => {
+  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
@@ -21,7 +22,7 @@ const SignupPage: React.FC = () => {
     }
 
     try {
-      await signup(email, password);
+      await signup(email, password, name);
       setSuccessMessage('新規登録が成功しました。ログインページにリダイレクトします。');
       setTimeout(() => {
         navigate('/login');
@@ -40,6 +41,14 @@ const SignupPage: React.FC = () => {
       <h1 className="text-6xl font-bold mb-8">lift_log</h1>
       <h2 className="text-2xl mb-6">新規登録</h2>
       <form onSubmit={handleSignup} className="flex flex-col items-center">
+        <input
+          type="text"
+          placeholder="ユーザーネーム"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-80 p-2 mb-4 bg-input-bg text-input-text border-none rounded focus:outline-none placeholder:text-input-placeholder"
+          required
+        />
         <input
           type="email"
           placeholder="メールアドレス"

--- a/frontend/tests/user-registration.spec.ts
+++ b/frontend/tests/user-registration.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ユーザー新規登録 E2E テスト', () => {
+  test.beforeEach(async ({ page }) => {
+    // テスト実行前にサインアップページに移動
+    await page.goto('/signup');
+  });
+
+  test('正常な新規登録フローが動作すること', async ({ page }) => {
+    // ユニークなメールアドレスを生成（テスト実行時の重複を避けるため）
+    const timestamp = Date.now();
+    const testEmail = `test-user-${timestamp}@example.com`;
+    const testPassword = 'SecurePassword123';
+
+    // ページタイトルと見出しの確認
+    await expect(page.locator('h1')).toHaveText('lift_log');
+    await expect(page.locator('h2')).toHaveText('新規登録');
+
+    // フォームフィールドの存在確認
+    const nameInput = page.locator('input[placeholder="ユーザーネーム"]');
+    const emailInput = page.locator('input[type="email"]');
+    const passwordInput = page.locator('input[type="password"]').first();
+    const passwordConfirmInput = page.locator('input[type="password"]').nth(1);
+    const submitButton = page.locator('button[type="submit"]');
+
+    await expect(nameInput).toBeVisible();
+    await expect(emailInput).toBeVisible();
+    await expect(passwordInput).toBeVisible();
+    await expect(passwordConfirmInput).toBeVisible();
+    await expect(submitButton).toBeVisible();
+
+    // フォームに入力
+    await nameInput.fill('Test User');
+    await emailInput.fill(testEmail);
+    await passwordInput.fill(testPassword);
+    await passwordConfirmInput.fill(testPassword);
+
+    // APIレスポンスを待機するためのネットワークリクエストをモック
+    await page.route('**/api/v1/users', async (route) => {
+      if (route.request().method() === 'POST') {
+        // 成功レスポンスをモック
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: '12345678-1234-1234-1234-123456789012',
+            name: 'Test User',
+            email: testEmail,
+            passwordHash: 'hashedPassword',
+            createdAt: new Date().toISOString()
+          })
+        });
+      }
+    });
+
+    // 登録ボタンをクリック
+    await submitButton.click();
+
+    // 成功メッセージの表示を確認
+    await expect(page.locator('text=新規登録が成功しました')).toBeVisible();
+
+    // ログインページへのリダイレクト（タイムアウトを考慮して少し待機）
+    await page.waitForURL('/login', { timeout: 3000 });
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('パスワード不一致時にエラーメッセージが表示されること', async ({ page }) => {
+    const timestamp = Date.now();
+    const testEmail = `test-mismatch-${timestamp}@example.com`;
+
+    // フォームに入力（パスワードを異なるものにする）
+    await page.locator('input[placeholder="ユーザーネーム"]').fill('Test User');
+    await page.locator('input[type="email"]').fill(testEmail);
+    await page.locator('input[type="password"]').first().fill('Password123');
+    await page.locator('input[type="password"]').nth(1).fill('DifferentPassword456');
+
+    // 登録ボタンをクリック
+    await page.locator('button[type="submit"]').click();
+
+    // エラーメッセージの表示を確認
+    await expect(page.locator('text=パスワードが一致しません')).toBeVisible();
+    
+    // ページが変遷していないことを確認
+    await expect(page).toHaveURL('/signup');
+  });
+
+  test('必須フィールドが空の場合にブラウザバリデーションが働くこと', async ({ page }) => {
+    // メールアドレスを空のまま登録ボタンをクリック
+    await page.locator('button[type="submit"]').click();
+
+    // ブラウザの標準バリデーションにより、フォームが送信されないことを確認
+    // （ページが変遷しないことで確認）
+    await expect(page).toHaveURL('/signup');
+  });
+
+  test('APIエラー時にエラーメッセージが表示されること', async ({ page }) => {
+    const timestamp = Date.now();
+    const testEmail = `test-error-${timestamp}@example.com`;
+    const testPassword = 'SecurePassword123';
+
+    // APIエラーレスポンスをモック
+    await page.route('**/api/v1/users', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            message: 'このメールアドレスは既に登録されています'
+          })
+        });
+      }
+    });
+
+    // フォームに入力
+    await page.locator('input[placeholder="ユーザーネーム"]').fill('Test User');
+    await page.locator('input[type="email"]').fill(testEmail);
+    await page.locator('input[type="password"]').first().fill(testPassword);
+    await page.locator('input[type="password"]').nth(1).fill(testPassword);
+
+    // 登録ボタンをクリック
+    await page.locator('button[type="submit"]').click();
+
+    // エラーメッセージの表示を確認
+    await expect(page.locator('text=このメールアドレスは既に登録されています')).toBeVisible();
+    
+    // ページが変遷していないことを確認
+    await expect(page).toHaveURL('/signup');
+  });
+
+  test('フォームのアクセシビリティが適切であること', async ({ page }) => {
+    // プレースホルダーテキストの確認
+    await expect(page.locator('input[placeholder="ユーザーネーム"]')).toBeVisible();
+    await expect(page.locator('input[placeholder="メールアドレス"]')).toBeVisible();
+    await expect(page.locator('input[placeholder="パスワード"]')).toBeVisible();
+    await expect(page.locator('input[placeholder="パスワード（確認）"]')).toBeVisible();
+
+    // ボタンテキストの確認
+    await expect(page.locator('button[type="submit"]')).toHaveText('登録');
+
+    // フォーカス操作のテスト
+    await page.locator('input[placeholder="ユーザーネーム"]').focus();
+    await expect(page.locator('input[placeholder="ユーザーネーム"]')).toBeFocused();
+
+    // Tab キーでナビゲーション
+    await page.keyboard.press('Tab');
+    await expect(page.locator('input[type="email"]')).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.locator('input[type="password"]').first()).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.locator('input[type="password"]').nth(1)).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await expect(page.locator('button[type="submit"]')).toBeFocused();
+  });
+
+  test('レスポンシブデザインが機能すること', async ({ page }) => {
+    // デスクトップサイズでの表示確認
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.locator('.w-80')).toBeVisible(); // フォーム要素の幅クラス
+
+    // モバイルサイズでの表示確認
+    await page.setViewportSize({ width: 375, height: 667 });
+    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.locator('form')).toBeVisible();
+    
+    // フォーム要素がビューポート内に収まっていることを確認
+    const formBounds = await page.locator('form').boundingBox();
+    expect(formBounds?.width).toBeLessThanOrEqual(375);
+  });
+});


### PR DESCRIPTION
## Summary
- permit unauthenticated POST /api/v1/users
- add MVC test ensuring unauthenticated user creation
- fix Lombok dependency scope in build

## Testing
- `./mvnw -q test` *(fails: Network is unreachable while resolving org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_689d5efcdc248333bdf2bad07fcae8b3